### PR TITLE
docs: proofread market user guides

### DIFF
--- a/gitbook-docs/market/user-guides/README.md
+++ b/gitbook-docs/market/user-guides/README.md
@@ -1,24 +1,14 @@
 ---
-description: Command line guide to proof market
+description: Guides for using Proof Market via CLI
 ---
 
-# User Guides
+# User guides
 
-Please see the appropriate guide based on your user role.
+Prerequisites for these guides are [environment setup](../../getting-started/environment-setup.md),
+[Proof Market toolchain installation](../../getting-started/installation.md),
+and [authentication on Proof Market](sign-up.md).
+Then you can proceed with the appropriate guide based on your role:
 
-* [Circuit Developer](circuit-developer.md)
-* [Proof Requester](proof-requester.md)
-* [Proof Producer](proof-producer.md)
-
-
-
-
-
-
-
-
-
-
-
-
-
+* [Circuit developer](circuit-developer.md)
+* [Proof requester](proof-requester.md)
+* [Proof producer](proof-producer.md)

--- a/gitbook-docs/market/user-guides/circuit-developer.md
+++ b/gitbook-docs/market/user-guides/circuit-developer.md
@@ -1,51 +1,71 @@
-# Circuit Developer
+# Circuit developer
 
-This is an entity that prepares circuits for the proof market. The most efficient way to create a circuit definition for Proof Market is [zkLLVM](https://github.com/NilFoundation/zkllvm). All dependencies and build instructions are inside the [zkLLVM's repository](https://github.com/NilFoundation/zkllvm).
+This is an entity that prepares circuits for Proof Market.
+The most efficient way to create a circuit definition for Proof Market is
+[zkLLVM](https://github.com/NilFoundation/zkllvm) circuit compiler.
+You can find the required dependencies and build instructions in the
+[zkLLVM's repository](https://github.com/NilFoundation/zkllvm).
 
-Anyone can generate circuits. They are serialised & published on the proof market. This allows the reuse of the circuits by all other proof requesters.&#x20;
+Anyone can generate circuits.
+They are serialized & published on Proof Market, allowing reuse of the circuits by
+all proof requesters.
 
-## Create a new circuit (using [zkLLVM](https://github.com/NilFoundation/zkllvm))
+## Create a circuit
 
-```
+Write a circuit and compile it with [zkLLVM](https://github.com/NilFoundation/zkllvm):
+
+```bash
 make -C ${ZKLLVM_BUILD:-build} <circuit target name> -j$(nproc)
 ```
 
+For more information on circuit development, read the [zkLLVM documentation](
+https://docs.nil.foundation/zkllvm/circuit-development/circuit-generation).
+
 ## Prepare a statement with a circuit description for Proof Market
 
-Circuits are stored as a _statement_ structure on Proof Market. Statement description example can be found in /example directory
+Circuits are stored on Proof Market in the form of statements.
+Example statements can be found in the `./example` directory.
 
+```bash
+python3 scripts/prepare_statement.py \
+    --circuit <zkllvm output> \
+    --type <circuit type> \
+    --output <statement description file> \
+    --name <statement name> \
+    --private | --public
 ```
-python3 scripts/prepare_statement.py -c <zkllvm output> \
--o <statement description file> \ 
--n <statement name> -t <circuit type>
-```
 
-Provide the necessary information listed in the output statement file
-
-## Publish to Proof Market
+## Publish a statement on Proof Market
 
 {% hint style="info" %}
-Ensure you have done the [Authentication](sign-up.md) setup before progressing
+[Sign up](sign-up.md) and keep authentication files in order to use
+the following command line tools.
 {% endhint %}
 
+You can find an authentication file example in the `/example` directory.
 
+The statement can be published on Proof Market via the Python script `statement_tools.py`:
 
-This statement can now be pushed to the Proof market via the Python script
+```console
+$ python3 scripts/statement_tools.py push 
+    --file <json file with statement description>
 
+Statement from /opt/zkllvm-template/build/template.json was pushed.
 ```
-python3 scripts/statement_tools.py push --file <json file with statement description> 
-```
 
-Authorisation file examples can be found in `/example` directory.
+## Retrieving statements
 
-You will be returned an object containing a _\_key_ filed -- unique descriptor of the statement
+A list of all available statements can be obtained by this command:
 
-## Published circuit id
-
-A list of all available statements can be obtained by
-
-```
+```bash
 python3 scripts/statement_tools.py get
 ```
 
-\
+To retrieve a selected statement/circuit definition and its metadata
+uploaded upon the statement's publishing:
+
+```bash
+python3 scripts/statement_tools.py get \
+    --key <key of the statement> \
+    --output <output file> 
+```

--- a/gitbook-docs/market/user-guides/proof-producer.md
+++ b/gitbook-docs/market/user-guides/proof-producer.md
@@ -1,82 +1,72 @@
-# Proof Producer
+# Proof producer
 
 {% hint style="info" %}
-Ensure you have done the [Authentication](sign-up.md) setup before progressing
+[Sign up](sign-up.md) and keep the authentication files in order to use
+the following command line tools.
 {% endhint %}
 
-## Submit Ask order
+## Submit a proposal
 
-The Proof producers can submit asks for circuits and specify an accompanying cost.
+Proof producers can submit proposals for statements and specify an accompanying cost like this:
 
-```
-python3 scripts/ask_tools.py push --cost <cost of the ask> --key <key of the statement> 
-```
-
-## Order Status/Fetch Inputs
-
-The proof producer can check their ask with
-
-```
-python3 scripts/ask_tools.py get --key <key of the ask> 
+```bash
+python3 scripts/proposal_tools.py push \
+    --cost <cost of the proposal> \
+    --key <key of the statement>
 ```
 
-Ask's status 'processing' means that the ask was matched with a bid. Now it is time to generate a proof for the proof producer.
+## Check order status and fetch inputs
 
-First of all, the proof producer needs circuit definition:
+Producers can check their proposal using `proposal_tools`:
 
+```bash
+python3 scripts/proposal_tools.py get --key <key of the proposal>
 ```
 
-python3 scripts/statement_tools.py get --key <key of the statement> -o <output file> 
+If the proposal's status is `processing`, it means that the proposal was matched with the request.
+Now it's time for the proof producer to generate the proof.
 
+First of all, the proof producer needs statement definition:
+
+```bash
+python3 scripts/statement_tools.py get \
+    --key <key of the statement>\
+    --output <output file>
 ```
 
-Next, public input of the bid:
+Next, public input of the request:
 
-```
-python3 scripts/public_input_get.py --key <bid key> -o <output file path> 
-```
-
-## Proof Generation
-
-Execute the below to generate proof:
-
+```bash
+python3 scripts/public_input_get.py \
+    --key <request key> \
+    --output <output file path>
 ```
 
+## Generate a proof 
+
+To generate proof execute the following:
+
+```bash
 cd build
-./bin/proof-generator/proof-generator --proof_out=<output file> --circuit_input=<statement from Proof Market> --public_input=<public input from Proof Market>
-# Or using the multithreaded version
-./bin/proof-generator/proof-generator-mt --proof_out=<output file> --circuit_input=<statement from Proof Market> --public_input=<public input from Proof Market> --smp=<number of threads> ----shard0-mem-scale=<scale>
-
+./bin/proof-generator/proof-generator \
+    --proof_out <output file> \
+    --circuit_input <statement from Proof Market>
+    --public_input <public input from Proof Market>
 ```
 
-For multithreaded versions, the following flags warrant discussion as the computation of proof requires temporary space. This is always allocated to `core0`/`shard0.`
+## Submit a proof
 
-* `smp` : Number of threads. This is ideally the number of CPU cores on the system. ex: If you have a 16 core CPU &  16 GB RAM & set `smp` to 16. Each core gets access to 1 GB of RAM. Thus `core0`/`shard0` will have access to 1 GB of RAM.
-* `shard0-mem-scale`: Weighted parameter (`weight`) to reserve memory for `shard0.`This is a natural number which allows for `shard0` to have more access to RAM in comparison to others. ex: If you have a 16 core CPU &  16 GB RAM & set `smp` to 8 and set `shard0-mem-scale` to 9.
+The proof producer can now submit the proof to the marketplace, where they will get the reward
+if the proof is verified by Proof Market.
+You can learn more about
+[rewards and commissions](../economics.md#funds-transferring-and-commissions), as well as about
+[penalties](../economics.md#penalties), on the [Economics page](../economics.md).
 
-&#x20;We first compute  `ram_per_shard` variable as follows:
-
-```
-ram_per_shard = TOTAL_RAM / (smp + shard0-mem-scale -1)
-              = 16 / (8 + 8)
-              = 1
-```
-
-This equates to the following:&#x20;
-
-* `shard0` RAM =`shard0-mem-scale` \* `ram_per_shard` = 9 GB
-* `shard1` .... `shard7` = `ram_per_shard` = 1 GB/per core= 7 GB
-
-These two variables need to be tuned per the architecture/circuit for which the proof is generated.
-
-
-
-## Proof Submission
-
-The proof generator can now submit the proof to the marketplace, where they will get the reward if verified.
-
-```
-python3 scripts/proof_tools.py push --bid_key <key of the bid> --ask_key <key of the ask> --file <file with the proof> 
+Submitting a proof via `proof_tools.py`:
+```bash
+python3 scripts/proof_tools.py push \
+    --request_key <key of the request> | --proposal_key <key of the proposal> \
+    --file <file with the proof>
 ```
 
-You can provide only one of two possible keys.&#x20;
+Note that you can provide only one of the two possible keys.

--- a/gitbook-docs/market/user-guides/proof-requester.md
+++ b/gitbook-docs/market/user-guides/proof-requester.md
@@ -1,29 +1,35 @@
-# Proof Requester
+# Proof requester
 
 {% hint style="info" %}
-Ensure you have done the [Authentication](sign-up.md) setup before progressing
+[Sign up](sign-up.md) and keep the authentication files in order to use
+the following command line tools.
 {% endhint %}
 
-## Submit Bid Order
+## Submit a request
 
-The proof requester can create an order. An order has additional details such as who is requesting the proof and what they are willing to pay for it
+A request order has additional details, such as who requests the proof and what they are willing
+to pay for it.
+The proof requester can create an order like this:
 
-```
-python3 scripts/bid_tools.py push --cost <cost of the bid> --file <json file with public_input> --key <key of the statement> 
-```
-
-## Order Status
-
-The proof requester can check their bid with
-
-```
-python3 scripts/bid_tools.py get --key <key of the bid> 
+```bash
+python3 scripts/request_tools.py push \
+    --cost <cost of the request> \
+    --file <json file with public_input> \
+    --key <key of the statement> 
 ```
 
-## Get Proof
+## Check order status
 
-Now the proof requester can get their proof either by bid key or proof key.
+Proof requesters can check their requests with the following command:
 
+```bash
+python3 scripts/request_tools.py get --key <key of the request>
 ```
-python3 scripts/proof_tools.py get --bid_key <key of the bid> 
+
+## Obtain the proof
+
+The proof requester can get their proof either by request key or proof key:
+
+```bash
+python3 scripts/proof_tools.py get --request_key <key of the request>s
 ```

--- a/gitbook-docs/market/user-guides/sign-up.md
+++ b/gitbook-docs/market/user-guides/sign-up.md
@@ -1,24 +1,40 @@
 # Sign up
 
-Access to the market requires authentication. Please ensure you have a valid username/password. If you have not registered, please look at the instructions on how to do so [here](../front-end.md#new-user-signup) via the front end.
+Access to the market requires authentication.
+Make sure you have a valid username and password.
+If you have not registered, please look at the instructions on how to do so
+[via the web interface](../front-end.md#new-user-signup).
 
-Or, you can use the below command line in the `proof-market-toolchain` repository.
+Or, you can use the following command in the `proof-market-toolchain` repository.
 
 ## User
 
-Users can submit/retrieve orders on the proof market. You cannot generate proofs if you sign up as an ordinary user.
+Signup for an ordinary user through CLI looks like this:
 
-```
-python3 scripts/signup.py user -u <username> -p <password> -e <e-mail>
-```
-
-## Proof Producer
-
-Proof Producers can submit/retrieve orders on the proof market and have the additional ability to submit/generate proofs.&#x20;
-
-```
-python3 scripts/signup.py producer -u <username> -p <password> -e <e-mail>
+```bash
+python3 scripts/signup.py user \
+    --user <username> \
+    --password <password> \
+    --email <e-mail>
 ```
 
-If successful, this creates a _.user_ and a _.secret_ file in `scripts/`  the directory with your credentials.
+If the signup is successful, this command creates `.user` and `.secret` files with your credentials
+in the `./scripts` directory.
 
+All users can submit and retrieve orders on Proof Market, but only proof producers
+can generate and submit proofs.
+
+## Proof producer
+
+First, you should sign up or [sign in](../cmd-reference/user.md#signing-in) as a regular user,
+and then you can register yourself as a proof producer:
+
+```bash
+python3 scripts/signup.py producer \
+    --eth_address <producer's Ethereum address> \
+    [--description <producer's description>] \
+    [--url <link to a website>] \
+    [--logo <logo>]
+```
+
+Note that only Ethereum address is a required parameter, the others are optional.


### PR DESCRIPTION
Docs: review and proofreading of the Proof Market documentation, [User Guides](https://docs.nil.foundation/proof-market/market/user-guides) section with all its pages.

Includes:
 - [x] proofread for User Guides pages, fixed inaccuracies and added the needed cross-links - part of #66 
 - [x] updated CLI commands formatting to more convenient style
 - [x] bid/ask -> request/proposal rename – part of #63
 - [x] proof key updates and ETH address from #69 and #77
 - [x] private/public option for statements from #81 and #82