### PR TITLE
docker: add python3 and Python dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 # syntax=docker/dockerfile:1
-
+# Build:
+# docker build -t ghcr.io/nilfoundation/proof-market-toolchain:tag -t ghcr.io/nilfoundation/proof-market-toolchain:latest .
 FROM ghcr.io/nilfoundation/proof-market-toolchain:base
 
 WORKDIR /proof-market-toolchain
 
 COPY . /proof-market-toolchain
 
-RUN ./build.sh \
-      && ln -s /proof-market-toolchain/build/bin/proof-generator/proof-generator /usr/bin/proof-generator
+RUN pip3 install --no-cache-dir -r /proof-market-toolchain/requirements.txt \
+    && ./build.sh \
+    && ln -s /proof-market-toolchain/build/bin/proof-generator/proof-generator /usr/bin/proof-generator

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,5 +1,6 @@
 # syntax=docker/dockerfile:1
-# build to ghcr.io/nilfoundation/proof-market-toolchain:base
+# Build:
+# docker build -t ghcr.io/nilfoundation/proof-market-toolchain:base --file Dockerfile.base .
 
 ARG BOOST_VERSION=1.76.0
 ARG BOOST_VERSION_UNDERSCORED=1_76_0
@@ -47,6 +48,7 @@ ARG BOOST_SETUP_DIR
 COPY --from=boost_builder ${BOOST_SETUP_DIR} ${BOOST_SETUP_DIR}
 ENV BOOST_ROOT=${BOOST_SETUP_DIR}
 
+
 RUN DEBIAN_FRONTEND=noninteractive \
     set -xe \
     && apt-get update \
@@ -67,6 +69,8 @@ RUN DEBIAN_FRONTEND=noninteractive \
         libssl-dev \
         libyaml-cpp-dev \
         pkg-config \
+        python3 \
+        python3-pip \
         ragel \
         systemtap-sdt-dev \
         wget \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -58,6 +58,7 @@ RUN DEBIAN_FRONTEND=noninteractive \
         build-essential \
         clang-12 \
         cmake \
+        emacs \
         git \
         gnutls-dev \
         libc-ares-dev \
@@ -68,11 +69,14 @@ RUN DEBIAN_FRONTEND=noninteractive \
         libsctp-dev \
         libssl-dev \
         libyaml-cpp-dev \
+        mc \
+        nano \
         pkg-config \
         python3 \
         python3-pip \
         ragel \
         systemtap-sdt-dev \
+        vim \
         wget \
         xfslibs-dev \
     && apt-get clean \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-requests
+requests==2.28.2


### PR DESCRIPTION
#  docker: add python3 and Python dependencies

Install Python3, pip3 and dependencies for the scripts/*.py.
Currently, the only dependency is the `requests` module.

Resolves #75

#  docker: add popular editors

Add popular editors that users might use:

* emacs
* mc
* nano
* vim