### PR TITLE
prepare_statement: toggle private and public statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,9 +318,19 @@ Statement description example can be found in `example/statements/` directory
 
 Please ensure you have selected the option to create *ll IR files in the [zkLLVM setup](https://github.com/NilFoundation/zkllvm#2-configure-cmake).
 
+```bash
+python3 scripts/prepare_statement.py \
+    -c <zkllvm output> \
+    -o <statement description file> \
+    -n <statement name> \
+    -t <statement type> \
+    --private | --public
 ```
-python3 scripts/prepare_statement.py -c <zkllvm output> -o <statement description file> -n <statement name> -t <statement type>
-```
+The `--private` or `--public` parameters are mutually exclusive:
+
+* With `--private`, the statement will be accessible only by its ID.
+  For experiments and development purposes, make your statements private.
+* With `--public`, the statement will be openly listed on the Proof Market.
 
 Provide the necessary information listed in the output statement file
 

--- a/scripts/prepare_statement.py
+++ b/scripts/prepare_statement.py
@@ -2,14 +2,15 @@ import os
 import json
 import argparse
 
-def prepare(circuit_file, output_file, name, statement_type):
+
+def prepare(circuit_file, output_file, name, statement_type, private):
     data = {
         "name": name,
         "description": "description",
         "url": "url",
         "input_description": "input_description",
         "type": statement_type,
-        "isPrivate": False,
+        "isPrivate": private,
         "definition": {
             "verification_key": "verification_key",
             "proving_key": "proving_key",
@@ -25,27 +26,35 @@ def prepare(circuit_file, output_file, name, statement_type):
 
     with open(output_file, "w") as f:
         json.dump(data, f, indent=4)
-    
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "-c", "--circuit", type=str, required=True, help="zkllvm compiler output"
+        "-c", "--circuit", type=str, required=True, help="Path to a zkLLVM circuit (*.ll)"
     )
     parser.add_argument(
         "-o",
         "--output",
-        metavar="output file",
+        metavar="output_file_path",
         type=str,
         required=True,
-        help="output file",
+        help="Output file",
     )
-    parser.add_argument("-n", "--name", type=str, required=True, help="name")
+    parser.add_argument("-n", "--name", type=str, required=True,
+                        help="Statement name that will be shown on the Proof Market")
     parser.add_argument(
         "-t",
         "--type",
+        metavar="statement_type",
         type=str,
         required=True,
-        help="statement type: placeholder-zkllvm or placeholder-vanilla",
+        help="Statement type: placeholder-zkllvm or placeholder-vanilla",
     )
+    private = parser.add_mutually_exclusive_group(required=True)
+    private.add_argument('--private', action='store_true',
+                         help="Make a statement private: only accessible by ID")
+    private.add_argument('--public', action='store_false',
+                         help="Make a statement public: visible on the Proof Market")
     args = parser.parse_args()
-    prepare(args.circuit, args.output, args.name, args.type)
+    prepare(args.circuit, args.output, args.name, args.type, args.private)


### PR DESCRIPTION
Resolve #81

---

Now the help looks like this:
```console
$ python3 scripts/prepare_statement.py --help
usage: prepare_statement.py [-h] -c CIRCUIT -o output_file_path -n NAME -t statement_type [--private | --public]

options:
  -h, --help            show this help message and exit
  -c CIRCUIT, --circuit CIRCUIT
                        Path to a zkLLVM circuit (*.ll)
  -o output_file_path, --output output_file_path
                        Output file
  -n NAME, --name NAME  Statement name that will be shown on the Proof Market
  -t statement_type, --type statement_type
                        Statement type: placeholder-zkllvm or placeholder-vanilla
  --private             Make a statement private: only accessible by ID
  --public              Make a statement public: visible on the Proof Market
```