### PR TITLE
docs: proofread requester-producer flow and mina pipeline

### DIFF
--- a/gitbook-docs/guides-1/mina-proof-pipeline-example/1.-setup.md
+++ b/gitbook-docs/guides-1/mina-proof-pipeline-example/1.-setup.md
@@ -1,41 +1,48 @@
-# 1. Setup
+# Part 1. Setup
 
-MINA proofs are computationally heavy; hence, users need to use the proof market to generate proofs to have a MINA state proof validated in EVM.
+Mina proofs are computationally heavy; hence, proof producers can benefit from
+using Proof Market to generate Mina state proofs for their further in-EVM validation.
 
-You need to set up the following environments to follow along with this guide.
+You're going to need the following environments ready for this guide.
 
-## 1. Proof Market&#x20;
+## Step 1: Proof Market
 
-Please ensure you have done the following steps:
+Prerequisites from the Proof Market side are:
 
-* [Installation](../../guides/installation.md):  Clone the repository. You don't need to build anything, as we will only be using Python scripts.
-* [Authentication](../../market/user-guides/sign-up.md): Set up the `proof-market-toolchain` authentication as a user. You do not need to create a Proof Producer profile.
+* [Environment setup](../getting-started/environment-setup.md).
+* [Proof Market toolchain installation and setup](../../getting-started/installation.md).
+  You don't need to set up a virtual environment for the Proof Market toolchain,
+  we will only be using its Python scripts.
+  This directory will be referred to as `proof-market-toolchain` home in the guide.
+* [Authentication on Proof Market](../../market/user-guides/sign-up.md).
+  There's no need to register as a producer, any account will suffice.
 
-This will be referred to as `proof-market-toolchain` the home in the guide
+## Step 2: Mina state proof
 
-## 2. Mina State Proof&#x20;
+Mina state proof repository maintained by `=nil;` Foundation
+comprises the following artifacts:
+* Solidity EVM verifier;
+* C++ circuits;
+* scripts to fetch Mina state (ledger) and Mina account state (user/zkApp).
 
-Mina state-proof repository maintains the following artifcats
+Clone the [Mina state proof repository](https://github.com/NilFoundation/mina-state-proof)
+and run `npm i` from the project's directory to install all its dependencies.
+This directory will be referred to as `mina-state-proof` home in the guide.
 
-* Solidity EVM verifier&#x20;
-* C++ circuits
-* Scripts to fetch mina state (ledger) , mina account state (user/zkApp)
+## Step 3: Mina zkApp
 
-&#x20;Please clone the repository located [here](https://github.com/NilFoundation/mina-state-proof) and install any dependencies.&#x20;
+Mina zkApp project consists of a sample zkApp located at `mina-state-proof/examples/mina-add-zkapp`
+with 8 state variables that are updated on each interaction.
+This directory will be referred to as `mina-add-zkApp` home in the guide.
 
-This will be referred to as `mina-state-proof` home in the guide
+Follow the steps from
+[`mina-add-zkapp/README.md`](https://github.com/NilFoundation/mina-state-proof/tree/master/examples/mina-add-zkapp)
+to install the project dependencies.
 
-## 3. Mina zkApp
+After that, you should have the following three directories ready:
 
-Mina zkApp project consists of a sample zkApp with 8 state variables that are updated on each interaction. This is located at `mina-state-proof/examples/mina-add-zkapp` . Please follow the steps to Install the project dependencies present at `mina-state-proof/examples/mina-add-zkapp/README.md`.&#x20;
-
-This will be referred to as `mina-add-zkApp` home in the guide
-
-At the end of this step, you should have 3 folders representing the three repositories above as follows
-
-```
+```bash
 proof-market-toolchain/
 mina-state-proof/
 mina-state-proof/examples/mina-add-zkapp/
 ```
-

--- a/gitbook-docs/guides-1/mina-proof-pipeline-example/2.-deploy-zkapp.md
+++ b/gitbook-docs/guides-1/mina-proof-pipeline-example/2.-deploy-zkapp.md
@@ -1,18 +1,15 @@
-# 2. Deploy zkApp
+# Part 2. Deploying zkApp
 
-Please navigate to the `mina-add-zkapp` home directory.
+The following steps, performed from `mina-add-zkapp` home directory,
+deploy the test zkApp to the `Berkeley` test net.
 
-The following steps deploy the zkApp to `Berkeley` testnet
+## Step 1: generate a key pair
 
-## 1. Generate key-pair&#x20;
+Let's start with generating test keys:
 
-```
-npm run build && node build/src/generateKeyPairs.js
-```
+```console
+$ npm run build && node build/src/generateKeyPairs.js
 
-This command outputs :
-
-```
 --------WARNING: UNSECURE KEYS DO NOT USE IN PRODUCTION ENV----------------
 
 --------------------------------------------------------------------------
@@ -24,47 +21,106 @@ user public key  : B62xxxxxxxxxxxxxxxxxxxxxxxx
 --------------------------------------------------------------------------
 ```
 
-The user should update&#x20;
+Copy these keys to the corresponding paths:
+* `zkApp` key pair to `keys/berkeley.json`;
+* `user` key pair to `keys/user.json`.
 
-* `zkApp` key pair to `keys/berkeley.json`
-* `user` key pair to `keys/user.json`
+The format for these JSON files is:
+```json
+{
+    "privateKey": "YOUR_PRIVATE_KEY",
+    "publicKey": "YOUR_PUBLIC_KEY"
+}
+```
 
-Only the user wallet **must** be funded by requesting faucet funds on `BERKELEY` network here by providing the public key:  [https://faucet.minaprotocol.com/](https://faucet.minaprotocol.com/)
+On https://faucet.minaprotocol.com you can fund your Mina wallet on `Berkeley` network
+by requesting faucet funds using your **public** key.
+**Only your wallets** should be funded this way.
 
 {% hint style="warning" %}
-You must wait for your user wallet to be funded before progressing. This can take approximately 3-5 minutes.
+You must wait for your wallet to be funded before progressing.
+This depends on your transaction appearing in a completed block, which can take approximately 3-5 minutes.
 {% endhint %}
 
+## Step 2: build the project
 
-
-## 2. Build Project
-
-```
+To build the project, run:
+```bash
 npm run build
 ```
 
-## 3. Deploy Project
+## Step 3: deploy the project
 
-```
+Upon deployment, zkApp's 8 state variables will be initialized to `1,2,3,4,5,6,7,8`.
+
+```bash
 zk deploy berkeley
 ```
 
-zkApp  8 state variables initialized to `1,2,3,4,5,6,7,8` The contract has a method `update` which increments the zkApp state fields by `1,2,3,4,5,6,7,8` each of them respectively.
+The test `Add` contract has the only method, `update`, that increments the zkApp state fields
+by `1,2,3,4,5,6,7,8` each of them respectively.
+Note that state values are represented in the hexadecimal numeral system.
 
-## 4. Interact with zkApp
+## Step 4: check the account state
 
+To fetch zkApp or user data, you're going to need the `get_mina_state.py` script
+located in `mina-state-proof/scripts`.
+You can either navigate to the `mina-state-proof` home or add `../../` before `scripts/get_mina_state.py`.
+
+```bash
+$ python3 scripts/get_mina_state.py \
+    --output mina_zkapp_state.json \
+    account --address YOUR_PUBLIC_KEY
 ```
-node build/src/interact.js berkeley
+
+The output file you provided will be populated with JSON
+detailing the account/zkApp state:
+
+```json
+{
+    "public_key": "YOUR_PUBLIC_KEY",
+    "balance": {
+        "liquid": "0",
+        "locked": "0"
+    },
+    "state":
+        "0x0000000000000000000000000000000000000000000000000000000000000001,
+        0x0000000000000000000000000000000000000000000000000000000000000002,
+        0x0000000000000000000000000000000000000000000000000000000000000003,
+        0x0000000000000000000000000000000000000000000000000000000000000004,
+        0x0000000000000000000000000000000000000000000000000000000000000005,
+        0x0000000000000000000000000000000000000000000000000000000000000006,
+        0x0000000000000000000000000000000000000000000000000000000000000007,
+        0x0000000000000000000000000000000000000000000000000000000000000008",
+    "proof_extension": "..."
+}
 ```
 
-Every interaction calls the `update` method which increments values as follows:
+## Step 5: interacting with zkApp
 
-* `update#1` values changed to `2,4,6,8,10,12,14,16`
-* `update#2` values changed to `3,6,9,12,15,18,21,24`.
+This step is performed from `mina-add-zkapp` home.
+It will compile the contract and call its method `update`.
+This may take some time, but if successful you will see a link to your transaction on `Berkeley`:
 
+```console
+$ node build/src/interact.js berkeley
 
+compile the contract...
+build transaction and create proof...
+send transaction...
 
+Success! Update transaction sent.
 
+Your smart contract state will be updated
+as soon as the transaction is included in a block:
+https://berkeley.minaexplorer.com/transaction/...
+```
 
+Every interaction through this script calls the contract's `update` method,
+incrementing the values as follows:
+* after the first update state values will be changed to `2,4,6,8,a,c,e,10`;
+* after the second update state values will be changed to `3,6,9,c,f,12,15,18`;
+* and so on.
 
-
+Once your transaction is included in a block, in approximately 3-5 minutes,
+you can [check the state values](#step-4-check-your-state-values) again and see if they changed.

--- a/gitbook-docs/guides-1/mina-proof-pipeline-example/3.-proof-request.md
+++ b/gitbook-docs/guides-1/mina-proof-pipeline-example/3.-proof-request.md
@@ -1,222 +1,166 @@
-# 3. Proof Request
+# Part 3. Request a proof
 
-We will next collect the information required to submit a proof request for our data to be validated on EVM.
+In this part, we will collect the information required to submit a proof request
+to be validated on EVM and post such a request.
 
-Please navigate to the `mina-state-proof` home directory.
+## Step 1: collecting the data
 
-## 1 . Get Public Input
+For proof validation in the smart contract, we're going to need Mina's ledger hash and our account state.
+Navigate to the `mina-state-proof` home directory.
 
-### Ledger State Proof
+### Get ledger state
 
-To fetch the ledger data (entire mina network state), execute the following :&#x20;
+First, let's get the ledger data — the entire Mina network state:
 
+```console
+$ python3 scripts/get_mina_state.py \
+    --output mina_ledger_state.json \
+    ledger
+
+Fetching data for block height: 5612
+Hash: jwkscPfXvGVVvgm92wroiXBJXE8bRt18S2ue1Uk9k5awGSFCfSM
 ```
-python3 scripts/get_mina_state.py --output=mina_ledger_state.json ledger
-```
 
-The output file contains the `snarkedLedgerHash` attribute identifies the ledger hash; this will be used in the validation of the proof in the smart contract.
+Both the output of the command and the output file contain the `Hash`/`snarkedLedgerHash` attribute
+that identifies the ledger:
 
-```
+```json
       "blockchainState": {
-        ....
-        "snarkedLedgerHash": "jwmapuNzu8YKee3RzbYQeWa5mqj1LoMiPohBEc3pfyR9gN3csQ5",
-
+        ...
+        "snarkedLedgerHash": "jwkscPfXvGVVvgm92wroiXBJXE8bRt18S2ue1Uk9k5awGSFCfSM",
       }
 ```
 
-### Account State Proof
+### Get account state
 
-To fetch the zkApp or user data, execute the following:
+If you haven't already, [get the zkApp's state](2.-deploy-zkapp.md#step-4-check-the-account-state).
 
-```
-python3 scripts/get_mina_state.py --output=mina_zkapp_state.json account --address B62qp64bbYKBnSuNa7yHHu7UpqPivao9TWwrH11Bs5gT1DPRXvwHRuY
-```
+## Step 2: send proof requests
 
-_replace "B62qp......" with the public key of your zkApp/user account (i.e. `berkeley.json`_  for zkApp and `user.json` for users account)
+This step and the further ones are performed from the `proof-market-toolchain` home.
 
-The output file contains the following structure detailing the account/zkApp state.
+You can get all statements published on Proof Market like this:
 
-```json
+```console
+$ python3 scripts/statement_tools.py get
+
 {
-              "zkappState": [
-                   "2",
-                   "4",
-                   "6",
-                   "8",
-                  "10",
-                  "12",
-                  "14",
-                  "16"
-              ],
-              "balance": {
-                  "liquid": "48900000000",
-                  "locked": "0",
-                  "stateHash": "3NKVQGUedEspG3RVUZTTr8fLZuZDJM9Ly7rWG4eM89VRmRR8F5kn"
-             },
-
-}
-
-```
-
-This will be used in the validation of the account proof in the smart contract.
-
-## 2. Send Proof Request
-
-Please navigate to the `proof-market-toolchain` home directory.
-
-We need two proofs of this data to be validated in EVM.&#x20;
-
-We can get all circuits on the proof market via&#x20;
-
-```
-python3 scripts/statement_tools.py get
-```
-
-Output:
-
-```json
-{
-    .....
+    ...
     "_key": "32292",
      "description": "mina state proof",
      "url": "https://github.com/NilFoundation/mina-state-proof"
 },
 {
-    .....
-    "_key": "79169223",    
+    ...
+    "_key": "79169223",
     "description": "Account state proof for Mina",
     "url": "https://github.com/NilFoundation/mina-state-proof"
 }
 ```
 
-* The \_key `32292` is the mina ledger proof circuit key, this is used for Ledger state proof
-* The \_key `79169223` is the mina account state proof circuit key, this is used for Account state proof
+Look for the following keys in the statement list:
+* `_key` **32292** is the key for Mina ledger proof statement (circuit)
+  which we'll use for Ledger state proof;
+* `_key` **79169223** is the key for Mina account state proof.
 
-### Ledger State Proof
+That's the two proofs we want to be validated in EVM.
+For that, we're going to use the [`request_tools.py` script](../../market/cmd-reference/ask.md)
+from the Proof Market toolchain:
 
-This proof validates the full ledger state. This is requested by executing the following:
-
-```
-python3 scripts/request_tools.py push --cost <cost of the bid> --file mina_ledger_state.json --key <key of the statement> 
-```
-
-* _key:_ Mina circuit key&#x20;
-* _cost :_ Cost of ordering proof&#x20;
-
-ex:
-
-```sh
-python3 scripts/request_tools.py push --cost 10 --file ../mina-state-proof/mina_ledger_state.json --key 32292
+```bash
+python3 scripts/request_tools.py push \
+    --cost <cost of the request> \
+    --file <file scr/path> \
+    --key <key of the statement> 
 ```
 
-Output
+Visit the market's web interface at [proof.market](https://proof.market/) to check out
+current prices, as they may change based on demand.
 
-<pre class="language-json"><code class="lang-json"><strong>{
-</strong>   "_key":"65017881",
+### Request a ledger state proof
+
+This proof should validate the full ledger state:
+
+```console
+$ python3 scripts/request_tools.py push \
+    --cost 16 \
+    --file ../mina-state-proof/mina_ledger_state.json \
+    --key 32292
+
+{
+   "_key":"65017881",
    "statement_key":"32292",
    "status" : "created"
-    ....
+    ...
 }
-</code></pre>
 
-_Note the \_key of your bid. We will use this to retrieve proof or check the order status._
+We will use the `_key` of that request to check the order status and retrieve the proof.
+The key of this order is `65017881`, and the status for now is `created`.
 
-The key of our order is `65017881` , and the status is `created`
+### Request an account state proof
 
-### Account state Proof
+This proof validates the Merkle path of zkApp's state to the ledger state hash:
 
-This proof validates the Merkle path of the user state to the above ledger state hash.  This is requested by executing the following.&#x20;
+```console
+$ python3 scripts/request_tools.py push \
+    --cost 16 \
+    --file ../mina-state-proof/mina_zkapp_state.json \
+    --key 79169223
 
-```
-python3 scripts/request_tools.py push --cost <cost of the bid> --file mina_zkapp_state.json --key <key of the statement> 
-```
-
-ex:
-
-```
-python3 scripts/request_tools.py push --cost 10 --file ../mina-state-proof/mina_zkapp_state.json --key 79169223
-```
-
-Output
-
-<pre class="language-json"><code class="lang-json"><strong>{
-</strong>   "_key":"727121",
+{
+   "_key":"727121",
    "statement_key":"79169223",
-   "status" : "created"
-    ....
+   "status": "created"
+    ...
 }
-</code></pre>
-
-_Note the \_key of your bid. We will use this to retrieve proof or check the status of the order._
-
-The key of our order is `727121` , and the status is `created`
-
-## 3. Get Proof
-
-You must wait until your order status changes form `created` to `completed.`
-
-Order status evolves as follows
-
-1. `created` : Order is placed on the order book
-2. `processing` : Order is matched, and proof is being generated
-3. `completed` : Order is now fulfilled, and the proof has been submitted.
-
-Your order status can be checked by executing:
-
-```
-python3 scripts/request_tools.py get --key=<key of your order>
 ```
 
-### Ledger State Proof
+The key of this order is `727121`, and the status is also `created`.
 
-Once your order status is completed, you can retrieve the proofs. Note the _proof\_key,_ as we will be using this to retrieve the proof.
+## Step 3: obtaining the proofs
 
-```sh
-python3 scripts/request_tools.py get --key=6501788
+You must wait until your order status changes from `created` to `completed`.
+You can learn more about orders' statuses on the [Economics page](../../market/economics.md#orders-status).
+
+You can check the order status through the [market's web interface](https://proof.market/)
+or via CLI like this:
+
+```bash
+python3 scripts/request_tools.py get --key <key of the order>
 ```
 
-Output
+### Get the ledger state proof
 
-```json
+Once your order status goes to `completed`, you can retrieve the proof.
+You're going to need the `proof_key` from the response:
+
+```console
+$ python3 scripts/request_tools.py get --key 6501788
+
 {
-         "proof_key" : 44958982 
-         "status": "completed",
+    "proof_key": 44958982,
+    "status": "completed"
 }
 ```
 
-Get Ledger Proof
+With this `proof_key`, you can get the ledger proof from the market like this:
 
-```sh
-python3 scripts/proof_tools.py get -p 44958982 -f ledger_proof.bin
+```console
+$ python3 scripts/proof_tools.py get \
+    --proof_key 44958982 \
+    --file ledger_proof.bin
+
+Proof is saved to ledger_proof.bin
 ```
 
-_p:_ proof key.
+### Get the account state proof
 
-_f:_ file where we want the proof to be saved.
+Same as above, once the order status is `completed`, we can fetch the account state proof:
 
-### Account state Proof
+```console
+$ python3 scripts/proof_tools.py get \
+    --proof_key 542042 \
+    --file account_proof.bin
 
-Same as above, we will fetch the Account state proof once the order status is complete.
-
-```sh
-python3 scripts/request_tools.py get --key=727121
+Proof is saved to account_proof.bin
 ```
-
-Output
-
-```json
-{
-         "proof_key": 542042,
-         "status": "completed",
-}
-```
-
-Get Account Proof
-
-```sh
-python3 scripts/proof_tools.py get -p 542042 -f account_proof.bin
-```
-
-_p:_ Is the proof key.
-
-_f:_ is the file where we want the proof to be saved.

--- a/gitbook-docs/guides-1/mina-proof-pipeline-example/4.-validate-proof.md
+++ b/gitbook-docs/guides-1/mina-proof-pipeline-example/4.-validate-proof.md
@@ -1,99 +1,155 @@
-# 4. Validate Proof
+# Part 4. Proof validation
 
-## Validation Steps
+These steps are performed from the `mina-state-proof` home directory.
 
-### 1. Inputs Proofs
+## Step 1: collecting the data
 
-To summarise, we require the below-mentioned artefacts to validate the proof.
+If everything went well, you now have two files with proofs,
+and all that's left to do is to verify them.
+For that you'll need:
 
-* Ledger state proof
-  * _File with the Ledger proof from the proof market._
-  * _Ledger hash which this proof attests to._ &#x20;
-* Account state proof
-  * _File with the account proof from the proof market._
-  * _Ledger hash which this proof attests to. (same as above ledger state proof)_
-  * _Account data._&#x20;
+* For ledger state proof:
+    * file with the ledger proof from Proof Market;
+    * ledger hash which this proof attests to.
+* Account state proof:
+    * file with the account proof from Proof Market;
+    * ledger hash which this proof attests to (same as for ledger state proof);
+    * account state data (in JSON).
 
-### 2. Launch Hardhat node
+## Step 2: launch a Hardhat node
 
-Open a terminal and execute the following to launch a hard hat node.
+Execute the following to launch a Hardhat node:
 
+```console
+$ npx hardhat node
+
+Started HTTP and WebSocket JSON-RPC server at http://127.0.0.1:8545/
+
+Accounts
+========
+WARNING: These accounts, and their private keys, are publicly known.
+Any funds sent to them on Mainnet or any other live network WILL BE LOST.
+
+Account #0: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 (10000 ETH)
+Private Key: 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+...
+
+WARNING: These accounts, and their private keys, are publicly known.
+Any funds sent to them on Mainnet or any other live network WILL BE LOST.
 ```
-npx hardhat node
+
+Don't close the terminal and don't finish this process, the Hardhat node should be
+running for the next steps.
+
+## Step 3: deploy contracts
+
+From another terminal, execute the following in the `mina-state-proof` home:
+
+```console
+$ npx hardhat deploy --network localhost
+
+Nothing to compile
+No need to generate any newer typings.
+deploying "mina_base_gate0" (tx: <ID>)...: deployed at <ID> with x gas
+...
+deploying "MinaState" (tx: <ID>)...: deployed at <ID> with x gas
 ```
 
-### 3 . Deploy contracts
+Hardhat reuses old deployments; to force re-deploy, add the `--reset` flag to the command.
 
-Please navigate to `mina-state-proof`  home and execute the following from another terminal shell.
+## Step 4: validation
 
-```
-npx hardhat deploy  --network localhost 
-```
+Once the contracts are deployed, we can use them to validate proofs.
+Below are two Hardhat proposals that execute flows to validate the ledger and account states.
+Note these work against the above deployment, so you must run the deployment
+and wait for it to finish before continuing.
 
-Hardhat re-uses old deployments; to force re-deploy, add the `--reset` flag above
+### Validating the ledger state
 
-### &#x20;4. Validate
+Insert the ledger hash and the path to the mina ledger state proof to the following command:
 
-Below are two hard hat tasks that execute flows to validate the ledger and account states. Please note these work against the above deployment. Hence, you must run the deployment before executing the following.
-
-#### Validate Ledger State
-
-```sh
+```bash
 npx hardhat validate_ledger_state \
---proof ./ledger_proof.bin \
---ledger jwYPLbRQa4X86tSJs1aTzusf3TNdVTj58oyWJQB132sEGUtKHcB  \
---network localhost
+    --proof ../proof-market-toolchain/ledger_proof.bin \
+    --ledger LEDHER_HASH \
+    --network localhost
 ```
 
-Inputs
+For example, there's a test ledger state in the repo, you can validate it:
 
-* _proof: File path with the full mina ledger state proof retrieved from the proof market._
-* _ledger: Hash of the ledger that this proof attests._
-* _network: Network to run this task against_
+```console
+$ npx hardhat validate_ledger_state \
+    --proof ./test/data/proof_state.bin \
+    --ledger jwYPLbRQa4X86tSJs1aTzusf3TNdVTj58oyWJQB132sEGUtKHcB \
+    --network localhost
 
-Please replace the ledger and proof parameters to validate the proof you retrieved from the proof market.
+jwYPLbRQa4X86tSJs1aTzusf3TNdVTj58oyWJQB132sEGUtKHcB
+{
+  ...
+  events: [
+    {
+      event: 'LedgerProofValidated',
+      eventSignature: 'LedgerProofValidated()',
+      ...
+    },
+    {
+      event: 'LedgerProofValidatedAndUpdated',
+      eventSignature: 'LedgerProofValidatedAndUpdated()',
+      ...
+    }
+  ]
+}
+```
 
-#### Validate Account State
+### Validating account state
 
 {% hint style="info" %}
-Proof validation for account state is in development. These commands show the API usage.
+Proof validation for account state is still in development.
+These commands show the API usage.
 {% endhint %}
 
-```sh
-npx hardhat validate_account_state \
---proof ./account_proof.bin  \
---state ./examples/data/account_data.json \
---ledger jwYPLbRQa4X86tSJs1aTzusf3TNdVTj58oyWJQB132sEGUtKHcB \
---network localhost
-```
-
-Inputs
-
-* _proof: File path of the account state proof retrieved from the proof market_
-* _state: File path of the account state to which the above proof attests to._
-* _ledger: Hash of the ledger against which the account state is validated._
-* _network: Network to run this task against._
-
-#### Account state file structure
+Upon [checking the account state](2.-deploy-zkapp.md#step-4-check-the-account-state),
+it was saved to `mina_zkapp_state.json` in the `mina-state-proof` home.
+There's also an example of account data at `examples/data/account_data.json`.
+Basically, it should look like this:
 
 ```json
 {
-  "public_key": public key of zkApp/User Account,
-  "balance": {
-    "liquid": Unlocked balance in MINA,
-    "locked": Locked/Staked balance in MINA 
-  },
-  "state": 8-byte state of zkApp/user account
+    "public_key":YOUR_PUBLIC_KEY,
+    "balance": {
+        "liquid": Unlocked balance in MINA,
+        "locked": Locked/Staked balance in MINA
+    },
+    "state": 8-byte state of zkApp/user account,
+    "proof_extension": id
 }
-
 ```
 
-See `examples/data/account_data.json` , for example. The `state` needs to be converted into a padded comma-separated string.
+The `state` needs to be converted into a padded comma-separated string.
 
-To see validation of account bytes in Ethereum, replace the following parameters
+To see validation of account bytes in Ethereum, replace the following parameters:
+* proof: file path to the account state proof that is validated (a dummy variable for now).
+* ledger: hash of the ledger against which the account state is validated.
+  This should be the hash that has already been committed in the previous step.
+* state: file path to the account state to which the above proof attests.
 
-* _proof: Dummy variable_
-* _ledger: Hash of the ledger against which the account state is validated. This should be the hash which has already been committed in the previous step._
-* _state: File path of the account state to which the above proof attests to updated based on structure/example._
+```bash
+npx hardhat validate_account_state \
+    --proof ../proof-market-toolchain/account_proof.bin \
+    --state ./mina_zkapp_state.json \
+    --ledger LEDGER_HASH \
+    --network localhost
+```
 
-Congratulations! If you have reached here, you have now managed to validate both ledger and account proofs in Ethereum.
+For example, there's a test account state in the repo:
+
+```bash
+npx hardhat validate_account_state \
+    --proof ./account_proof.bin \
+    --state ./examples/data/account_data.json \
+    --ledger jwYPLbRQa4X86tSJs1aTzusf3TNdVTj58oyWJQB132sEGUtKHcB \
+    --network localhost
+```
+
+Congratulations! If you have reached here, you have now managed to validate both ledger
+and account proofs in Ethereum.

--- a/gitbook-docs/guides-1/mina-proof-pipeline-example/README.md
+++ b/gitbook-docs/guides-1/mina-proof-pipeline-example/README.md
@@ -1,3 +1,6 @@
-# Mina Proof pipeline - Example
+# Mina proof pipeline example
 
-This section describes a step-by-step workflow to validate MINA proofs in EVM via the =nil;Proof Market.
+This section describes a step-by-step workflow to validate MINA proofs in EVM
+via `=nil;` Proof Market.
+
+Start here: [Mina proof pipeline example, step 1](1.-setup.md).


### PR DESCRIPTION
Docs: review and proofreading of the Proof Market documentation, [Requester/Producer workflow](https://docs.nil.foundation/proof-market/guides/requester-producer-flow) and [Mina example](https://docs.nil.foundation/proof-market/guides/mina-proof-pipeline-example) section with all its pages.

Should include:
 - [x] proofread for Requester/Producer workflow and Mina pipeline example pages, fixed inaccuracies and added the needed cross-links - part of #66
 - [x] updated CLI commands formatting to more convenient style
 - [x] bid/ask -> request/proposal rename – part of #63
 - [x] proof key updates from #69 and #77

TODO:
 - rename guides-1 folder and set up redirects for its pages