### PR TITLE
Add compatibility with boost 1.82

### DIFF
--- a/bin/proof-generator-mt/src/aspects/prover_vanilla.cpp
+++ b/bin/proof-generator-mt/src/aspects/prover_vanilla.cpp
@@ -23,6 +23,7 @@
 #include <boost/property_tree/ini_parser.hpp>
 #include <boost/program_options/parsers.hpp>
 #include <boost/filesystem.hpp>
+#include <boost/filesystem/string_file.hpp>
 
 namespace std {
     template<typename CharT, typename TraitsT>

--- a/bin/proof-generator/src/aspects/prover_vanilla.cpp
+++ b/bin/proof-generator/src/aspects/prover_vanilla.cpp
@@ -23,6 +23,7 @@
 #include <boost/property_tree/ini_parser.hpp>
 #include <boost/program_options/parsers.hpp>
 #include <boost/filesystem.hpp>
+#include <boost/filesystem/string_file.hpp>
 
 namespace std {
     template<typename CharT, typename TraitsT>


### PR DESCRIPTION
If you try to build proof-generator with boost 1.82, it would fail complaining about absent `load_string_file` in boost::filesystem.

This is because `load_string_file` has been deprecated. However, it is still present and works fine, just prints a compilation warning if used. You just need to include the `string_file.hpp` header explicitly.

This diff makes it easier to compile the proof-market-toolchain by removing the requirement on boost 1.76.