### PR TITLE
Make prepare_statement.py executable

### DIFF
--- a/scripts/prepare_statement.py
+++ b/scripts/prepare_statement.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import os
 import json
 import argparse


### PR DESCRIPTION
Currently, you need to run `prepare_statement.py` like this:

```sh
python3 scripts/prepare_statement.py
```

Which is generally fine, but for executable scripts you actually can just add a shebang in the beginning `#!/usr/bin/env python3` to be able to just run the script as it is.

I've added this because I'm installing proof-market-toolchain to the system's /bin directory, and hunting down the full path to the script is quite tedious, instead of just typing `prepare_statement.py` in the console.